### PR TITLE
Add docstrings and type hints to functions

### DIFF
--- a/script2stlite/functions.py
+++ b/script2stlite/functions.py
@@ -432,21 +432,101 @@ def file_to_ou_base64_string(file_path: str) -> str:
         encoded: bytes = base64.b64encode(f.read())
         return encoded.decode("utf-8")
 ############################################################################### 
-def write_text_file(filename: str, content: str) -> str:
+def write_text_file(filename: str, content: str) -> None:
+    """
+    Write text content to a file.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to write to.
+    content : str
+        The text content to write to the file.
+
+    Returns
+    -------
+    None
+    """
     try:
         with open(filename, 'w') as f:
             f.write(content)
         print(f"Content successfully written to {filename}")
     except IOError:
         print(f"Error writing to {filename}")
-def replace_text(input_text: str, replace_flag: str, replace_text: str, add_stlite_punctuation: bool= True ) -> str:
-    if add_stlite_punctuation: return input_text.replace(replace_flag,"`" + replace_text + "`,")
-    else: return input_text.replace(replace_flag,replace_text)        
 
-def create_html(directory,app_settings,packages=None):
-    if packages is None: packages = {}
+def replace_text(input_text: str, replace_flag: str, replacement_text: str, add_stlite_punctuation: bool = True) -> str:
+    """
+    Replace a specific flag in the input text with replacement text.
+
+    Optionally adds stlite-specific backticks and commas around the replacement text.
+
+    Parameters
+    ----------
+    input_text : str
+        The original text.
+    replace_flag : str
+        The substring to be replaced.
+    replacement_text : str
+        The text to insert in place of the replace_flag.
+    add_stlite_punctuation : bool, optional
+        If True (default), encloses the replacement_text with backticks and a trailing comma
+        (e.g., "`replacement_text`,"). Otherwise, inserts replacement_text as is.
+
+    Returns
+    -------
+    str
+        The text with replacements made.
+    """
+    if add_stlite_punctuation:
+        return input_text.replace(replace_flag, f"`{replacement_text}`,")
+    else:
+        return input_text.replace(replace_flag, replacement_text)
+
+def create_html(directory: str, app_settings: Dict[str, Any], packages: Union[Dict[str, str], None] = None) -> str:
+    """
+    Generates an HTML file content for an stlite application.
+
+    This function takes directory, application settings, and optional package information
+    to populate an HTML template. It replaces placeholders in the template with
+    actual values like CSS links, JS links, Pyodide version, application name,
+    requirements, entrypoint, main application script content, and other files.
+
+    Parameters
+    ----------
+    directory : str
+        The root directory of the application where 'settings.yaml' and other app files are located.
+    app_settings : Dict[str, Any]
+        A dictionary containing application settings, typically loaded from 'settings.yaml'.
+        Expected keys include:
+        - '|STLITE_CSS|': URL for the stlite CSS file.
+        - '|STLITE_JS|': URL for the stlite JavaScript file.
+        - '|PYODIDE_VERSION|': Version of Pyodide to use.
+        - '|APP_NAME|': Name of the application.
+        - '|APP_REQUIREMENTS|': A list of Python package requirements.
+        - '|APP_ENTRYPOINT|': The main Python script for the application (e.g., 'streamlit_app.py').
+        - '|APP_FILES|': A list of other files to include in the stlite bundle.
+    packages : Union[Dict[str, str], None], optional
+        A dictionary mapping package names to specific versions. If None (default),
+        the latest versions specified in requirements are used. This allows for
+        pinning package versions if needed.
+
+    Returns
+    -------
+    str
+        The generated HTML content as a string.
+
+    Raises
+    ------
+    ValueError
+        If essential settings like CSS, JS, Pyodide version, or app entrypoint are missing,
+        or if the app entrypoint is not a '.py' file.
+    FileNotFoundError
+        If the HTML template or specified application files are not found.
+    """
+    if packages is None:
+        packages = {}
     #1 load html file
-    html = load_text_from_subfolder(subfolder='templates',filename='html_template.txt')
+    html = load_text_from_subfolder(subfolder='templates', filename='html_template.txt')
     
     #2) replace css
     if app_settings.get('|STLITE_CSS|') is not None:

--- a/script2stlite/script2stlite.py
+++ b/script2stlite/script2stlite.py
@@ -1,8 +1,38 @@
 from functions import load_all_versions,folder_exists,get_current_directory,create_directory,copy_file_from_subfolder,file_exists, load_yaml_from_file,create_html,write_text_file
 import os
 from pathlib import Path
+from typing import Union, Optional
 
-def s2s_prepare_folder(directory = None):
+def s2s_prepare_folder(directory: Optional[str] = None) -> None:
+    """
+    Prepares a folder for a script2stlite project.
+
+    This function performs the following actions:
+    1. Determines the target directory: Uses the provided `directory` or defaults
+       to the current working directory if `directory` is None.
+    2. Validates directory: If a directory is provided, it checks if it exists.
+    3. Creates 'pages' subdirectory: Ensures a 'pages' subdirectory exists within
+       the target directory, creating it if necessary.
+    4. Copies 'settings.yaml': If 'settings.yaml' does not already exist in the
+       target directory, it copies a template 'settings.yaml' file into it.
+       If 'settings.yaml' already exists, it prints a message and does not overwrite.
+
+    Parameters
+    ----------
+    directory : Optional[str], optional
+        The path to the directory where the project folder structure should be
+        prepared. If None (default), the current working directory is used.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        If the provided `directory` does not exist or if there's an issue
+        copying the 'settings.yaml' template file.
+    """
     #1. check if user provided a directory (or we will use current dir)
     if directory is not None: #directory is provided
         #check provided directory is valid
@@ -19,11 +49,106 @@ def s2s_prepare_folder(directory = None):
     else: print(f"* settings.yaml already exists in {directory}. NO NEW FILE CREATED. \n")        
     print(f"* Folder structure successfully created: {directory}. \n")
 
-        
+import os
+from pathlib import Path
+from typing import Union, Optional, Dict, Any
+
+def s2s_prepare_folder(directory: Optional[str] = None) -> None:
+    """
+    Prepares a folder for a script2stlite project.
+
+    This function performs the following actions:
+    1. Determines the target directory: Uses the provided `directory` or defaults
+       to the current working directory if `directory` is None.
+    2. Validates directory: If a directory is provided, it checks if it exists.
+    3. Creates 'pages' subdirectory: Ensures a 'pages' subdirectory exists within
+       the target directory, creating it if necessary.
+    4. Copies 'settings.yaml': If 'settings.yaml' does not already exist in the
+       target directory, it copies a template 'settings.yaml' file into it.
+       If 'settings.yaml' already exists, it prints a message and does not overwrite.
+
+    Parameters
+    ----------
+    directory : Optional[str], optional
+        The path to the directory where the project folder structure should be
+        prepared. If None (default), the current working directory is used.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        If the provided `directory` does not exist or if there's an issue
+        copying the 'settings.yaml' template file.
+    """
+    #1. check if user provided a directory (or we will use current dir)
+    if directory is not None: #directory is provided
+        #check provided directory is valid
+        if not folder_exists(directory): raise ValueError(f'''* {directory} does not exist on this system.''')
+    else:  #nodirectory provided, use cd
+        directory = get_current_directory()
+        print(f"* No user directory provided. Creating new s2stlite project in current directory ({directory}). \n")
+    #2. check if pages folder exists, if not, create it
+    create_directory(os.path.join(directory,'pages'))
+    #3. create settings fileif it doesn't exist.
+    if not file_exists(os.path.join(directory,'settings.yaml')):
+        if not copy_file_from_subfolder(subfolder='templates',filename='settings.yaml',destination_dir=directory):
+            raise ValueError(f'''* Issue copying settings template.''')
+    else: print(f"* settings.yaml already exists in {directory}. NO NEW FILE CREATED. \n")
+    print(f"* Folder structure successfully created: {directory}. \n")
 
 
+def s2s_convert(
+    stlite_version: Optional[str] = None,
+    pyodide_version: Optional[str] = None,
+    directory: Optional[str] = None,
+    packages: Optional[Dict[str, str]] = None
+) -> None:
+    """
+    Converts a Streamlit application project into a single HTML file using stlite.
 
-def s2s_convert(stlite_version = None, pyodide_version = None, directory = None, packages = None):
+    This function performs the following steps:
+    1. Determines the target directory (current working directory if not specified).
+    2. Loads stlite, JavaScript, and Pyodide versions (uses latest if not specified).
+    3. Reads 'settings.yaml' from the target directory.
+    4. Updates settings with the chosen stlite, JS, and Pyodide versions.
+    5. Ensures the main app entrypoint is not duplicated in the app files list.
+    6. Validates that all files listed in settings exist.
+    7. Generates the HTML content using `create_html`.
+    8. Writes the generated HTML to a file named after the app_name in `settings.yaml`.
+
+    Parameters
+    ----------
+    stlite_version : Optional[str], optional
+        The specific version of stlite to use (e.g., "0.46.0"). If None (default),
+        the latest available version is used. This also determines the default
+        JavaScript version.
+    pyodide_version : Optional[str], optional
+        The specific version of Pyodide to use. If None (default), the latest
+        available version compatible with the chosen stlite_version is used.
+    directory : Optional[str], optional
+        The root directory of the Streamlit application project. If None (default),
+        the current working directory is used. This directory must contain
+        'settings.yaml' and all application files.
+    packages : Optional[Dict[str, str]], optional
+        A dictionary mapping package names to specific versions, which can be used
+        to override versions specified in requirements. If None (default),
+        versions from requirements or latest available are used.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        - If the specified `directory` does not exist.
+        - If `stlite_version` is provided but not supported.
+        - If 'settings.yaml' is not found in the directory.
+        - If any file listed in 'settings.yaml' under 'APP_FILES' is not found.
+    """
     #0. read/set directory
     if directory is not None: #directory is provided
         #check provided directory is valid


### PR DESCRIPTION
This commit adds comprehensive docstrings and type hints to the following functions:

- `script2stlite/functions.py`:
  - `write_text_file`
  - `replace_text`
  - `create_html`
- `script2stlite/script2stlite.py`:
  - `s2s_prepare_folder`
  - `s2s_convert`

The return type of `write_text_file` was corrected from `str` to `None`. The parameter `replace_text` in `replace_text` function was renamed to `replacement_text` for better clarity.