### PR TITLE
Fix: Replace deprecated use_column_width and add README for multi-pag…

### DIFF
--- a/example/Example_1_multi_page_image_editor/README.md
+++ b/example/Example_1_multi_page_image_editor/README.md
@@ -1,0 +1,102 @@
+# Example 1: Multi-Page Image Editor - Using `script2stlite`
+
+This example demonstrates how to use `script2stlite` to convert a multi-page Streamlit application, specifically an image editor, into a single self-contained HTML file. This application includes multiple Python files organized in a `pages` directory, an assets folder, and specific package requirements.
+
+`script2stlite` is a tool that packages your Streamlit application, along with its dependencies, into an HTML file that can be run in a web browser using [stlite](https://github.com/whitphx/stlite), without needing a Python backend server.
+
+## Application Structure
+
+The Image Editor application has the following structure:
+
+-   `app.py`: The main entry point for the Streamlit application. It sets up the overall page configuration.
+-   `pages/`: This directory contains the different pages of the application:
+    -   `01_Home.py`: The landing page.
+    -   `02_Upload_Image.py`: Page for uploading images.
+    -   `03_Adjust_Image.py`: Page for performing image adjustments like brightness, contrast, rotation, and grayscale.
+-   `assets/`: Contains static assets, like a sample image (`image.png`).
+-   `requirements.txt`: Lists the Python dependencies (Pillow for image manipulation).
+-   `settings.yaml`: The configuration file for `script2stlite`.
+
+## Steps to Convert This Streamlit App
+
+The process is similar to the simple app example, focusing on the configuration within `settings.yaml` to handle the multi-page structure and dependencies.
+
+### 1. Install `script2stlite`
+
+Ensure you have `script2stlite` installed. If not, you can typically install it using pip:
+
+```bash
+pip install script2stlite
+```
+*(Note: Refer to the main project README for the most up-to-date installation instructions.)*
+
+### 2. Prepare Your Project Folder
+
+If you were starting from scratch, you would use `converter.prepare_folder()`. This command creates a `settings.yaml` file (if one doesn't exist) and a `pages` directory. For this example, these are already provided.
+
+```python
+from script2stlite import Script2StliteConverter
+
+# Initialize the converter for this example's directory
+converter = Script2StliteConverter("example/Example_1_multi_page_image_editor")
+
+# Prepare the folder (optional if settings.yaml and pages/ already exist)
+# converter.prepare_folder()
+```
+
+### 3. Review and Modify `settings.yaml`
+
+The `settings.yaml` file is key to correctly packaging the multi-page application. Here's the content for this `Example_1_multi_page_image_editor`:
+
+```yaml
+APP_NAME: "Image Editor"
+APP_REQUIREMENTS:
+  - streamlit
+  - Pillow # For image manipulation
+APP_ENTRYPOINT: app.py # Main app file that sets page config
+APP_FILES:
+  - pages/01_Home.py
+  - pages/02_Upload_Image.py
+  - pages/03_Adjust_Image.py
+  - assets/image.png
+  # requirements.txt is processed separately by script2stlite if present,
+  # but can also be listed here if needed for other reasons.
+```
+
+Key aspects for a multi-page app:
+
+-   **`APP_NAME`**: Defines the application's title and the output HTML filename (e.g., `Image_Editor.html`).
+-   **`APP_REQUIREMENTS`**: Lists necessary Python packages. `Pillow` is crucial for the image processing features. Remember, these must be Pyodide-compatible.
+-   **`APP_ENTRYPOINT`**: This should be your main script, typically the one that might contain `st.set_page_config()` and acts as the primary entry point. For multi-page apps, this is often a small `app.py` or similar, while individual pages reside in the `pages/` directory.
+-   **`APP_FILES`**: This is where you list all the Python files for each page within the `pages` directory. You also include any assets like images or data files.
+    -   `script2stlite` automatically recognizes and processes the `pages/` directory convention for Streamlit multi-page apps if your entry point and page files are structured correctly. Listing them explicitly ensures they are included.
+    -   If a `requirements.txt` file is present in the directory, `script2stlite` will also attempt to install packages from it. It's good practice to also list them under `APP_REQUIREMENTS` for clarity and control, especially regarding versions.
+
+### 4. Convert the Application to HTML
+
+With `settings.yaml` configured, convert the application:
+
+```python
+from script2stlite import Script2StliteConverter
+
+# Initialize the converter
+converter = Script2StliteConverter("example/Example_1_multi_page_image_editor")
+
+# Convert the application
+converter.convert()
+
+print(f"Conversion complete! Check for '{converter.directory}/Image_Editor.html'.")
+```
+
+This command bundles `app.py`, all files in `pages/`, the assets, and the specified requirements into `Image_Editor.html`.
+
+### 5. View Your Application
+
+Open the generated `Image_Editor.html` in a web browser. You should see the multi-page image editor application, allowing you to navigate between home, upload, and adjust pages.
+
+You can view the output of this specific example hosted on GitHub Pages here:
+[https://lukeafullard.github.io/script2stlite/example/Example_1_multi_page_image_editor/Image_Editor.html](https://lukeafullard.github.io/script2stlite/example/Example_1_multi_page_image_editor/Image_Editor.html)
+
+---
+
+This example showcases how `script2stlite` handles multi-page applications and dependencies, making it easy to share complex Streamlit projects as single HTML files.

--- a/example/Example_1_multi_page_image_editor/pages/02_Upload_Image.py
+++ b/example/Example_1_multi_page_image_editor/pages/02_Upload_Image.py
@@ -38,7 +38,7 @@ def load_and_store_image(image_path, default_name="test_image.png"):
             del st.session_state['adjustment_params']
 
         st.success(f"'{default_name}' loaded successfully! Format: {image.format}. You can now go to the 'Adjust Image' page.")
-        st.image(image, caption=f"Loaded: {default_name}", use_column_width=True)
+        st.image(image, caption=f"Loaded: {default_name}", use_container_width=True)
         # It might be good to clear uploaded_file if it was set by st.file_uploader
         # However, st.rerun() might be needed, or careful state management.
         # For now, loading test image will overwrite previous upload.
@@ -93,7 +93,7 @@ if uploaded_file is not None:
             del st.session_state['adjustment_params']
 
         st.success(f"'{file_name}' uploaded successfully! Format: {image.format}. You can now go to the 'Adjust Image' page.")
-        st.image(image, caption=f"Uploaded: {file_name}", use_column_width=True)
+        st.image(image, caption=f"Uploaded: {file_name}", use_container_width=True)
 
     except IOError:
         st.error("The uploaded file is not a valid image or is corrupted. Please try another file.")
@@ -118,7 +118,7 @@ if 'uploaded_image_bytes' in st.session_state and uploaded_file is None:
     st.write("Current image in session:")
     try:
         current_img_preview = Image.open(io.BytesIO(st.session_state['uploaded_image_bytes']))
-        st.image(current_img_preview, caption=f"Current: {st.session_state.get('uploaded_image_name', 'N/A')}", use_column_width=True)
+        st.image(current_img_preview, caption=f"Current: {st.session_state.get('uploaded_image_name', 'N/A')}", use_container_width=True)
 
         col1, col2 = st.columns([0.7, 0.3])
         with col1:

--- a/example/Example_1_multi_page_image_editor/pages/03_Adjust_Image.py
+++ b/example/Example_1_multi_page_image_editor/pages/03_Adjust_Image.py
@@ -125,12 +125,12 @@ col1, col2 = st.columns(2)
 
 with col1:
     st.subheader("Original Image")
-    st.image(original_pil_image, caption=f"Original: {original_image_name}", use_column_width=True)
+    st.image(original_pil_image, caption=f"Original: {original_image_name}", use_container_width=True)
 
 with col2:
     st.subheader("Adjusted Image")
     if adjusted_image_bytes:
-        st.image(adjusted_image_bytes, caption="Adjusted Preview", use_column_width=True)
+        st.image(adjusted_image_bytes, caption="Adjusted Preview", use_container_width=True)
 
         # Prepare filename for download
         base, ext = os.path.splitext(original_image_name)


### PR DESCRIPTION
…e example

- Replaced `use_column_width` with `use_container_width` in the image editor example pages to resolve deprecation warning.
- Added a new README.md to `example/Example_1_multi_page_image_editor`.
  - The README explains the structure of the multi-page example.
  - It details the `settings.yaml` configuration for this example.
  - It includes a link to the hosted HTML version of the app.