### PR TITLE
Fix: Correct test image path for multi-page editor

### DIFF
--- a/example/Example_1_multi_page_image_editor/pages/02_Upload_Image.py
+++ b/example/Example_1_multi_page_image_editor/pages/02_Upload_Image.py
@@ -16,7 +16,7 @@ st.write(
 
 # Allowed file types
 ALLOWED_TYPES = ['jpg', 'jpeg', 'png']
-TEST_IMAGE_PATH = "example/Example_1_multi_page_image_editor/assets/image.png" # Path relative to repo root
+TEST_IMAGE_PATH = "assets/image.png" # Path relative to app root (app.py)
 
 # --- Test Image Loading Function ---
 def load_and_store_image(image_path, default_name="test_image.png"):


### PR DESCRIPTION
The previous path for the test image was relative to the repository root, causing issues when running the Streamlit app from its own directory.

This commit changes TEST_IMAGE_PATH in `pages/02_Upload_Image.py` to be `assets/image.png`, which is relative to the application root (where `app.py` is located). This ensures the test image loads correctly during local development and is consistent with the `script2stlite` packaging configuration.