### PR TITLE
Fix ModuleNotFoundError for functions module

### DIFF
--- a/script2stlite/script2stlite.py
+++ b/script2stlite/script2stlite.py
@@ -1,4 +1,4 @@
-from functions import load_all_versions,folder_exists,get_current_directory,create_directory,copy_file_from_subfolder,file_exists, load_yaml_from_file,create_html,write_text_file
+from .functions import load_all_versions,folder_exists,get_current_directory,create_directory,copy_file_from_subfolder,file_exists, load_yaml_from_file,create_html,write_text_file
 import os
 from pathlib import Path
 from typing import Union, Optional, Dict


### PR DESCRIPTION
Changed the import statement in script2stlite/script2stlite.py to use a relative import (from .functions import ...) to correctly locate the functions module within the same package.