### PR TITLE
Add README.md for Vizzu example

### DIFF
--- a/example/Example_6_vizzu/README.md
+++ b/example/Example_6_vizzu/README.md
@@ -1,0 +1,24 @@
+# Vizzu Streamlit Example
+
+This directory contains an example of a Streamlit application using Vizzu for interactive data visualizations.
+
+## Original Application
+
+The original Streamlit application was developed by Germán Andrés and Castaño Vásquez.
+
+- **Original GitHub Repository:** [gcastano/Streamlit-Demo-Apps/tree/main/StreamlitVizzu](https://github.com/gcastano/Streamlit-Demo-Apps/tree/main/StreamlitVizzu)
+- **Original Hosted Streamlit App:** [paris2024-olpympics-summary.streamlit.app/](https://paris2024-olpympics-summary.streamlit.app/)
+
+## stlite Version
+
+This example has been adapted to run as a static web page using `script2stlite`.
+
+- **stlite HTML Page:** [lukeafullard.github.io/script2stlite/example/Example_6_vizzu/Vizzu_example.html](https://lukeafullard.github.io/script2stlite/example/Example_6_vizzu/Vizzu_example.html)
+
+## Configuration Note
+
+This example demonstrates the use of a `config.toml` file. The `settings.yaml` for `script2stlite` includes the following entry to specify the configuration file:
+
+```yaml
+CONFIG: .streamlit/config.toml
+```


### PR DESCRIPTION
This README includes details about the original application, authors, and links to the original and stlite versions. It also notes the usage of config.toml.