### PR TITLE
Update stlite versions to 0.89.0

### DIFF
--- a/stlite_versions/js.yaml
+++ b/stlite_versions/js.yaml
@@ -1,3 +1,4 @@
+0.89.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.89.0/build/stlite.js
 0.88.1: https://cdn.jsdelivr.net/npm/@stlite/browser@0.88.1/build/stlite.js
 0.88.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.88.0/build/stlite.js
 0.87.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.87.0/build/stlite.js

--- a/stlite_versions/stylesheet.yaml
+++ b/stlite_versions/stylesheet.yaml
@@ -1,3 +1,4 @@
+0.89.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.89.0/build/stlite.css
 0.88.1: https://cdn.jsdelivr.net/npm/@stlite/browser@0.88.1/build/stlite.css
 0.88.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.88.0/build/stlite.css
 0.87.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.87.0/build/stlite.css


### PR DESCRIPTION
This commit updates js.yaml and stylesheet.yaml to include version 0.89.0 of stlite, pointing to the corresponding CDN resources.