### PR TITLE
feat: add test for web app generation

### DIFF
--- a/tests/generated_test_app.html
+++ b/tests/generated_test_app.html
@@ -25,7 +25,10 @@ mount(
     pyodideUrl: "https://cdn.jsdelivr.net/pyodide/v0.28.2/full/pyodide.js",
     files: {
 "app.py": `
-import streamlit as st\\nst.write('Hello, Streamlit!')
+
+import streamlit as st
+st.write('Hello, Streamlit!')
+
 `,
 
 },

--- a/tests/test_webapp_generation.py
+++ b/tests/test_webapp_generation.py
@@ -23,7 +23,10 @@ def test_simple_app_rendering_generation(tmp_path):
 
     # Create app.py
     with open(project_dir / "app.py", "w") as f:
-        f.write("import streamlit as st\\nst.write('Hello, Streamlit!')")
+        f.write("""
+import streamlit as st
+st.write('Hello, Streamlit!')
+""")
 
     # 2. Run the conversion
     s2s_convert(directory=str(project_dir))


### PR DESCRIPTION
This commit adds a new test to ensure that the package can produce web applications as expected.

The new test, `test_simple_app_rendering_generation`, performs the following steps:
1. Creates a simple Streamlit application in a temporary directory.
2. Runs the `s2s_convert` function to generate the HTML file for the application.
3. Asserts that the HTML file is generated successfully.
4. Copies the generated HTML file to the `tests` directory for manual verification, as requested by the user.

This test provides a way to verify the end-to-end functionality of the package, from project source to a generated web application.