### PR TITLE
feat: Add test for generating example apps

### DIFF
--- a/tests/generated_bitcoin_app.html
+++ b/tests/generated_bitcoin_app.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Current BTC vs USD Price Tracker</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.89.0/build/stlite.css"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module">
+import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.89.0/build/stlite.js"
+mount(
+  {
+    streamlitConfig : {},
+    requirements: ['streamlit', 'requests', 'plotly', 'pandas'],
+    entrypoint: "app.py",
+    pyodideUrl: "https://cdn.jsdelivr.net/pyodide/v0.28.2/full/pyodide.js",
+    files: {
+"app.py": `
+import streamlit as st
+import requests
+import pandas as pd
+import plotly.express as px
+from datetime import datetime
+
+# Define the API URL
+API_URL = "https://min-api.cryptocompare.com/data/v2/histoday?fsym=BTC&tsym=USD&limit=30"
+
+st.title("Bitcoin Price Viewer")
+
+st.image("assets/image.png")
+
+if st.button("Get Latest Bitcoin Price"):
+    try:
+        response = requests.get(API_URL)
+        response.raise_for_status()  # Raise an exception for bad status codes
+        data = response.json()
+
+        if data["Response"] == "Success":
+            btc_data = data["Data"]["Data"]
+
+            # Convert to DataFrame for easier manipulation and plotting
+            df = pd.DataFrame(btc_data)
+
+            # Convert UNIX timestamp to datetime
+            df["time"] = pd.to_datetime(df["time"], unit="s")
+
+            st.subheader("Bitcoin Price Data (Last 30 Days)")
+            st.dataframe(df[["time", "open", "high", "low", "close", "volumefrom", "volumeto"]])
+
+            # Create the plot
+            fig = px.line(df, x="time", y="close", title="Bitcoin Closing Price (USD)")
+            fig.update_xaxes(title_text='Date')
+            fig.update_yaxes(title_text='Price (USD)')
+            st.plotly_chart(fig)
+
+        else:
+            st.error(f"Error fetching data: {data.get('Message', 'Unknown error')}")
+
+    except requests.exceptions.RequestException as e:
+        st.error(f"Error connecting to API: {e}")
+    except KeyError as e:
+        st.error(f"Unexpected data format from API: Missing key {e}")
+    except Exception as e:
+        st.error(f"An unexpected error occurred: {e}")
+
+`,
+"assets/image.png": Ou("iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH6QYKChsma84+nwAAFpBJREFUeNrtnXt8VNW1x7/rnJlkJoEAAQyZhKeIVhAfKKiIV2vr41P1euurYmv1quVSkvioD9TeXnprLWorkgQtXqu1VW8VtVqvj6qlPhEQX6CgLahAMuGRgAKZmczjrPvHRBTIY5KZSc45mfX55A9C5sw5e3/3Wr+9z1p7C33YQgsCw8Uy9ketMYiOASkHhuz+UQaIYCoUAWbrxyICYYUosD35o9tBGhA2YMlniGyIe2Kr+8/cvKWvtq30lQeN3Bk4UE2OVWWSCBMVDhEYmNUvVRoxWKWwCoulYugSf0XD+hxYDrbwvGGjxGuehuq3FaYC+9nk1oLAq8AL6jFeKJhZV58Dy+bWXFN6pClynipnAAc5pAs+AOuphGE81m9W/Xs5sOwS4uaXH6CmXozq+cD+Dn+ctaCPiGH+3jerbm0OrB42rR6bH5Hmc8G4DPR4F4Z0RXgZS3/no/AxqVrbkgMrm629cMyAlmj4YkWuBcr6yLxjC3B3LI/aohnBxhxYGdVOwwNCYrbApUBBH53BhxXuR+VXBVX1dTmw0rBdC4YOM6y82YLOAHzkDCCiwj0a884tvGp9Qw6sroS8O8r9Ea9eDTob6JdjqU0LAbf78rhNZgRDObA6a63asvNE9TZgZI6dlGwjMNtXEfxfETQH1t4CoqZkNGrehXBqjpVu2auS4Ee+K4Mf58ACdA5GuLjsKhH9OVCY4yM9h6/KHP+24DyZQ7zPghWeHxiBoQ+AnJBjIqPDdbkY5oW9uchq9NrQqg5cgMHKHFRZ8ReT1bJWhGsC0/uMx9LqsflhI3SbKFU5AHqiweWPvrjMkKvrwq4FqzX0LQKZnOvxHrVlqnJOTy6s9hhYodryKaLWU0BJrp97xTarylkFVfVLXaOxQtWl3xW1Fueg6lUrEdGXQzWB810BVqQ6UCUii+i77/jsZPkCD0dqApWOBitUG7hehfm9OfvM2b59rlAdqQ7MdaTGitQGfq3KT3L9aOdVCbnFX1F/k2PAitQGblPl2lzPOcLm+iuDN9g+FIZrAnNyUDnKZodrSzMOVkY9Vqi27GpR/U2ur5wYFanwVQQX2A6sUHXZOSL6SE6oO9YsFT2noKLhz7YBK1RdPlnE+rvblhRk0AF4p83Bql+KFXwTa/N7YMXdDFdYxTixoKJuWa+DlXxNwwpgqNta2Zx4Cd7jb/7qF/Ew1tYPsBqWY218DSu4DBJRtz12g3qMo9ItpE0LLK0emx8h/BqiR7lx+HpPvQdz7Hfa/4PoLiL3Hw6xkNsefZmvadDxMufDbo+atPRQREIL3AoVCEbZlI4H1o4N7UPlLQTT69SHnxIevP3XvbLcEK4p/T7Jcix3YjX4QMQ/pGO1W7+k3f/zHHIRvsvXkHf2k3iOvRFj+DQw8x00rKgM1Zad193Pe7oHVclokAW42IzA0Z1PozpIFDACR4PHj1F6FEbpUXDErKRG2/Q2Vv2bWHWvYzWssHcjqC4Mzw8s9V8R3JB1j6Vz8ID5EMk9o9wLVtmxnbVEUry3OdxNpLSNlDOPH6P8ODxTrsVz3BwneK2BCPfpnK5z0uUPhIcEfgIcg6tNMAId5yJq4xo0sq3tRh06Ackv6sTbvemUpjippThQkVWwwjUlo0X5T1xuUjwOKRjabX1llHU+7hwDFqDCLUn5kwWwVBEw78HOJVreQsyx30H8g9MMgynoq+Cy7oNlxbEa3nLSWCsET5c0dcriPVJTOh3hW/YW3FPwnnpP61LA+uQiZsNbWHVvoLsaugBWCvqqPeHenr76OldbP4DoTof5cT0tVFN6dkFlw+MZA0vvKPdHxLrF/oL7K08hRSMxx4/EHP/9LoImGIFO1q+aPupAX41PQV8tcajylNv1/lHPyCWfRTICVsRr3QCMcBJY+zTKHqApuu0fJDa8ilW/BG14C41sb9VXB6Sgr95Mb5kiuBSH2uhwc/QK4Na0wWqeN7IUYvbPBM3rhzH0kNTHXvGBeIoPhMMubwXtn1gNy1NaxOwQrM7CqCawgsudO7FRbtxZPey+/lWbtqYFlnhjs1H7Zy0YpZPB8HS3uZDicZjF41IRBh3rq07CqLV1lQP11R5W5BXjGuD6bs8Km+eNLBXlcic8bSozuYxYtBlj7OnI4INA9mw+Y8jBKeirpTjdFGbtunO/km57LDFjNwF+R4AV6KE127x+eE/4VbKBW75AG1Yk02iCyzsV/U4W7nsvP3gM8zpov1im3bSZL+4oL87zWhtwwtZC3kJ8l69OIxT21FBPELl3ArTscANczTGRkUUV9U1dCoV5Xp2FQ/arEsNDfMV8rI2vQnSXbe/T2vqBW6BKei30si55rOQ+6qHPgGHOm7aYGCWHYpQfhzH8+GRmgU08mTatIfbaz5I6Sy03wBX0NQ0a3VZCYJtghatLL0TkQTc8ufiKMQ+fgeeImSCmPQDbsYHER4tIrP4TuivocCEv5xVU1i9KDazawGKUE3GRmeP+De/JtTaLjXESHz9B/J1adPs6pzbtC/7K4CmdgpV8i22uxYVlXHnnP9+FRdSeHPYWiXXPEH/jZnRnndOaVUXNA3xVG9d1LN7F+HdcWhtoffaSXWcfmGPPIH/635Mh2+6z273uXiXxg85nhSrn4Faz8YwxuWxSgOfYn5J/3nNIkYO2uRe+1yFY0eqyQ3HMOX/deP6hE7r92cTqh4m9WEli1QNo00dZndXJkIPJO/fp5GsqZyj4A1vuKp/49V/t4XMThnUO6t7TfFPJ7GwXrHXPYa1fTOLjJ1oFW3+M0qMwR5yAMeokZMCozMLlH0zeWY8Qe2EWiXXP2l9mWIlzgZVth0KVf3Wttxo4Gins5rJcWxmf0Z1Y6xcTe+1ntPxxKi0PTiO+ohpt3pzBqWwe3pMXpPSqqNedlsoZbYbCXQuGDgMmuBWszrNCO+AqhYxP/fwT4ktvpeWBycSevTS5z0Om4DrlLsQ3yOYyi4mhu8vL9gHL1LxTcPHh46kk4LULVlcKH6w4iU+eJ7rodGJ/nYmG0z+7UgqH4Tn6OtsHBYlZp+wbClVPxsVmlKfhsbqVkaAk/vkXog+flJHCVPPg6Uh/mx8qK5zclsY63rX6asCozOqrruAVbiT61PlYm95Oc2R4MA++wO5NPW0PsMLzAyOA8py+aoOrxgxU1MQjxJ67LO3rGKO+bfemDoTnDRu1Gyw15WhcbOksM2Qq41ObtxB/73/Se44hB4PH5icYmzJ1N1iGWjmwMqqv2rbE2qfTjOmG7VfkRZj0lcdCDnW1vupX2k03k8hoxbJuX5v2ir3k2Tv38kuWvhTv43Peqg1vlemMT7UysLWk7VeEDgMwdiwMDMHFhyelBVZdZgsfpGBo2hpJw012b/Li5prhAcPbot9wt75KY0aY4YplY9ikND1eIrOvjLLV5kZijIHBKPfqq5Hp6avgssw2+EHnpsdV08cQD9u/4VVHG1jGSLeCZZROBk10X19lsGLZKD8Wc8wpaV3D2vyuU4b0aAPREa4Fa/i07hdQRHchxQdmRCzL4IPwnrwg7WslPn3BGQ2vlHsUSt365jkd4W6UTyV/+mI03Ni6Ge0SrODSZNFDql7Q48Mz/gd4plwDef3S66vINqwNLzvDX8FQj8BgN0KV1FeB9K/jH4I59gzMsa3pRrEQVuNqtGk1uqMObd6MNm+C6I7kXg7+IUjRcIySIzBGfavTvRxS9larHnDMcSsKQz3AgNxssAvmLcAoPRJKj+y5jgo3En93oZOaf6gBDHInWG55S6XEX77BaVsfFRo4ZH8G23isHrb48nmOyHnfayzkewCv26CSoszoq173VEt+Sfydux3YAfg8dPPYE1t7q3Jnn2+gO9YTW3wdVt3rTn2EfHeClc4mbPFIr+U8WVtXkVh5H4l/POn0cxDjHiAK5LsKrDTWr6J/nYk2fohROjl5wFJgClI8bp9tITM964s9cwnWpndcokWIS6gmsF1goHv01QjyL+rmcSJq0XLvBLTli70cexFG6WTMkSdijDwxO8l20Z3El99BfOV9bjgeeJtHIIyLwEorTaZx9b5QAbTswPrspd2bisig/TH3/w7mQechA0dn5sbz+uM57r8w9j+N2HMz0NAWJ3dD2AB24SJLK00mxfpB3b6O+IpqWh6cRvSJs0l8tAgSLZm5/9LJ5J3/HMZ+Tk7qle0G0OQusNIpTO1qYp9iBZcSe+lKWv5wLIlVv89IGJPCYXjPfBAZOMap3dBkqLDVTfpK+nezik0tNI38K23eROyVm2h59DSsLe+n/yy+YvLOfBDxFTtQu+t2Q3APWGl5q/b0VVcBa1xN9PGzSKz+UwYGykgnlNbv25YQNLCocw9Y2ddXKVkiSmzxNSQ+TH9/YHP8hRj7TXSYx2KjAfJpbkaYjRNPldjLN6YfFsXAPPRyp3XFBgOsdW6ASoqGp6mvsnDGjSaIv3JT+l5rzKlgOueVrsJ6wxKPK8BKa5uipjUZ0VdtXnvzu+i2j9O7iLfAnrs9t2OxmLHGKKzcGHTDkoMxvPub5WT74KRMnE8oA/d3SlcEB1xdt631BbSuAjnBjnfpOWY2MmA0Vt3rySN3P/9kX6hKDsM84Mzud3xddk+Uz8jma37HLDt8CK2ZDSqyUhTbgSX5A/BMvBS8BZhjT092UmgLVnA52rACbQ4ig8djTryk+3ujq4U2LMv6c6R/EdMRVIkkN7j1AIglbyNqu5s0D74AvHse7ioF+yUhawUt7TDVtAaNfJ7dxs7ACrpT3h1aKsugdVMQwXjDfuibmIf8MPsNkWV9Jb6BGUmTdsxhTsqbu8FqPQelwVbeaswpSFH2a2k1y0fpmgdfCGZe+ve50xFgBQuq6ut2g5WMjWorr2UeemkPjC4r4xt/7OGtisfhmXx1+rfZvAX9Yr0TwHpl94Tqa7980TZLB0MnpLUulXrPG+Sd9xzek+7APOicjBZgGPsdSt5Zj2Qkzdna+Cqg9sdK5fnds/ndN28Zz4pNBLw58dIe+y4pGoFZNALzG+cn2+aL9Vj1S7A2vYM2foDVtAYSsS5dz3PY5ZgTLsrYKV7Wxlccoa6shGe3c9pj24ZwTeADenl3P/EPIf/itzKiSzLTq3Gspo/QHRtgVxDdFUSbt4AVQ2OhZAm9bxBG8YFIyWGZXyFPxGi5/wg0ss3mmp33CyqDh+3jsVrt6V4Ha+AorM3vYpQcbg+4DA/G0AkwtHdOg0l88qztoWr1UE9+/d+ePdcgeNQQZveqg2hYQfSJ74LHhzFsEkbZMcmfkiPs48V6EqxVDzjiPg2xFu0F2p4WrgmswY5nFhoejCEHY5RPwxg+DSMwGcx8V0NlbXyN6FPfs/+NCh/7K4IHteuxkn+kj6HyU/u1chxry0qsLSvhnQVg5mOUTsIom4pRPjUZOg0X1d6qRfzNuQ65V/7URmjc22M59LBxbyFGYApG+VQ8h17meMji79xNfMnNjsAqpcPG/ZWbPwVedlxPxJqTJ6CuvN/xUFmb3yW+7Han3O6Le0NFB17pd07tlJQKKrqwLtXjw/+L9cT+7+KM1Slm311Jm6y0CZavadBj2OzdYepgdf7Ct+Wh44k+ehrxJbckq5ttsqmZNq0h+uezM5K/1UMW9DcOfLKd5Ye2LVxdeiMiv3QaWPkXvdnhy2vdsZ6WP+wFn5mHMWwS5rizMMd/v1fUb2LVH4gtuRliISc19w3+yuDclD0WQIvHezcOK7+X/mWdZkS0mS2aiCZ3Rt6yquf1VN3rRB8/i9grNzoNqlBMpN1z8tpVuQN/vGF7qKbsd4Je4Zww2Hn5V0dlXp1/Xom/uxApGoFRPA4ZMKpbEwXd9g8S6/9O4qNH0aaPnLkaItxbVFHf1GWwACwjOte0vJcDBY4AK4UN16xg98HS7WuJv/GLr33Ak9z2u2gk4itG/IPAV5w8cV5aVYaVQCOfo6Et6Ofr0MY1TtJQ7VkE07itoz/oEKx+s7ZuilSX/lZFrnYEWJ1sEak71qM769sOo4P2RwpLOglbe2WbWnF0+7rkoQJ9yERY4J9ZV99hX3R2kbiVuA3B9ntBS7/STjdE66gaJ90w2odsV8xM3NbpIO/sD/pduWUzltr+3YJRNjW9MBjoXF9lM9vUOeJKf9V/5uYtaYMF4KPwN8A6e4PV+cJoRweHp6KvNLS1r2O10Zcvd6bUHymFmaq1LYrcYG+wju1EX21Ad7a9sY4MHNO5vsqFQVTkGpkRDGUMLICCyvpFKjxtxweWfqXIgJFpLDN0vlqfA4vF/ln1i1Ie6F3qwAQV2HHRVAwSK+9rXRPSboDVWRjVDsNoH7CQmInLRVKv6OjyUYWh2tIrRWWebZsgrx9GyeHJZMDyacm0YjFoeWBKu6Ew/5K3kcJhHeirf9Ly0Al9OATqVQUVDXd25TNdXjb2NzZURwYHzgC+actWiO7C2vga1sbXkiPHNwgZdkQH+mp0h1B1Jvrdb/KKvzFY3WXN2+WvmYOlHuMiYJsjRltkO9Znf0tvmSLLZfi2bTv4HLF+KHOwsg4WQMHMunqFH7uh8ay1TxN79lIS79+LNq4GtXL66iv7D39FQ7dKsNM6DjpUE6gRqHBVU+6l0cSTT8vD3+x7SCl3+6uC3XYeaYGlCyd5Iy0NixGOc20Dm15bZ5xmyZb6tOAEqVrb0itgAYSqy8pFdDlQSs7cYA0W5pGtW4h229KuxCmoqq+zhNOB5lyfON7CqvLddKHKCFgAhRXBd0TlfCCR6xvHWsKC6QVVmZmpZKx20FdV/4wIV+T6x5kmSEVhZfDJTF0vo0WpvorgAlRvynWT4+wGX2X9bzN5wYxXO/urGm4R5dZcXznGft5epY2twEqGxeBsRG7J9Znt7Rf+yuCc7ITWLFqoNnC9KHNz/Wc7U1WuL6gKZq2OX7L9BJHqQJUK83DaJiMunv2J6ixfVcPC7E4GesCaawJnGfAQDikjc7E1C0z3VQb/kv1ZZg9ZqLrsaBF9Ctgv17+9YvUJQ07vN6v+vZ74sh4LTwVV9UtVZRKwLNfHPa2oeN2Ke4/qKah6FKxWuOp8WvAvKlTnerunTO7x5Zd+s/Cq9T26e5D01uOGawLTgbuAAbnOz4ptU5UZBVX1j/UKzr355OH5gREY/BE4PsdBRkPf3xS5+MtzbfocWAD6KGZ4U9mVIvrfuVlj2r25UyxuzK8MLuhKRY0rwfoqNJaMBnMh8O0cId0aos8i/Li7qcSuBQtAFYnUBi4A5gLDc7CkZJ8qem1BZcPj9nKedhx7CwMFkSjXAdfmwmO7tkPhl34tmJ9OCnGfAutLa543slS8sdmi/Ajw5VhKNovAgmgetxfNCNp2BzdxQkuGqsvKQWeLcEkf9mC7RPWemNe6NZVthHJgdSlEjhnQEg1frMi1QFkfAWoTsDAaM6oHXF23zSk3LU5saa0emx+R0NnApcCJTn2ODswCXlLkXn/esCdlxtuOqz9zfIdE7ioZownzYuB8YJzDH2cN8Chx6/f+qzZ95uQHcdVIb7mrfKJlJc5VS84UYaITnK/A+wpPGxiL8ivrVrmlL9wWQr6aOtUMDxgkTgFOJvnKKGCTW6sHXkN50RLz+UzU8OXA6kULzw+MUINjDHSKqkxEmACUZPlrtwHvCfq+Km9j8LpdVsZzYGXRdtSWDfaKfgNLR6GMQBiuSEBgEFAMDBLwAyj0A7zALoGYJiu/Q8BWVRoFtiLUIfoJIp9alvmJW71RKvb/hvdWbexpQ7IAAAAldEVYdGRhdGU6Y3JlYXRlADIwMjUtMDYtMTBUMTA6Mjc6MzgrMDA6MDDHsFsoAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDI1LTA2LTEwVDEwOjI3OjM4KzAwOjAwtu3jlAAAAABJRU5ErkJggg=="),
+},
+  },
+  document.getElementById("root")
+)
+
+function Ou(n){const i=window.atob(n),a=i.length,l=new Uint8Array(a);for(let u=0;u<a;u++)l[u]=i.charCodeAt(u);return l}
+    </script>
+  </body>
+  <!-- We love stlite! https://github.com/whitphx/stlite and Pyodide https://github.com/pyodide/pyodide -->
+</html>

--- a/tests/test_example_generation.py
+++ b/tests/test_example_generation.py
@@ -1,0 +1,37 @@
+import pytest
+from pathlib import Path
+import shutil
+import yaml
+from script2stlite.script2stlite import Script2StliteConverter
+
+def test_bitcoin_app_generation(tmp_path):
+    # 1. Define paths
+    example_dir_src = Path("example/Example_2_bitcoin_price_app")
+    project_dir_tmp = tmp_path / "bitcoin_app"
+    output_dir = Path("tests")
+    output_filename = "generated_bitcoin_app.html"
+    output_html_path = output_dir / output_filename
+
+    # 2. Copy example project to a temporary directory
+    shutil.copytree(example_dir_src, project_dir_tmp)
+
+    # 3. Run the conversion in the temporary directory
+    converter = Script2StliteConverter(directory=str(project_dir_tmp))
+    converter.convert()
+
+    # 4. Locate the generated HTML file in the temporary directory
+    with open(project_dir_tmp / "settings.yaml", "r") as f:
+        settings = yaml.safe_load(f)
+    app_name = settings["APP_NAME"]
+    generated_filename = app_name.replace(" ", "_") + ".html"
+    generated_html_path = project_dir_tmp / generated_filename
+
+    # 5. Check that the HTML file was generated
+    assert generated_html_path.is_file(), f"Generated HTML file not found at {generated_html_path}"
+
+    # 6. Copy the generated HTML file to the tests folder
+    output_dir.mkdir(exist_ok=True)
+    shutil.copy(generated_html_path, output_html_path)
+
+    # 7. Final check in the tests directory
+    assert output_html_path.is_file(), f"HTML file not found in tests directory at {output_html_path}"


### PR DESCRIPTION
This test generates an HTML file for the Bitcoin price tracker example and saves it to the tests directory. This will be used for manual validation when stlite versions are updated.