### PR TITLE
chore: Update scikit-learn version for PixelHue example

### DIFF
--- a/example/Example_5_PixelHue/settings.yaml
+++ b/example/Example_5_PixelHue/settings.yaml
@@ -1,7 +1,7 @@
 APP_NAME: "PixelHue"  #give your app a nice name
 APP_REQUIREMENTS: #app requirements separated by a '-' on each new line. Requirements MUST be compatible with pyodide. Suggest specifying versions.
   - streamlit
-  - scikit-learn==1.6.1
+  - scikit-learn==1.7.0
   - numpy
   - pillow
 APP_ENTRYPOINT: main.py #entrypoint to app - change this to your main python file

--- a/tests/generated_Example_5_PixelHue.html
+++ b/tests/generated_Example_5_PixelHue.html
@@ -20,7 +20,7 @@ import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.89.0/build
 mount(
   {
     streamlitConfig : {},
-    requirements: ['streamlit', 'scikit-learn==1.6.1', 'numpy', 'pillow'],
+    requirements: ['streamlit', 'scikit-learn==1.7.0', 'numpy', 'pillow'],
     entrypoint: "main.py",
     pyodideUrl: "https://cdn.jsdelivr.net/pyodide/v0.28.2/full/pyodide.js",
     files: {


### PR DESCRIPTION
This commit updates the scikit-learn version from 1.6.1 to 1.7.0 in the settings.yaml file for the Example_5_PixelHue example.