### PR TITLE
fix(example7): Refactor to use settings.yaml for package loading

### DIFF
--- a/example/Example_7_shared_environment/README.md
+++ b/example/Example_7_shared_environment/README.md
@@ -2,10 +2,10 @@
 
 This example demonstrates the `SHARED_WORKER` mode of `script2stlite`. It consists of two separate Streamlit applications that share the same Python environment.
 
-- **Installer App**: This app uses `micropip` to install the `mpmath` package.
-- **User App**: This app imports and uses the `mpmath` package, even though it is not listed in its own requirements.
+- **Installer App**: This app's `settings.yaml` file lists `mpmath` as a requirement.
+- **User App**: This app can import and use the `mpmath` package because it shares the same environment as the 'Installer App', even though `mpmath` is not listed in its own requirements.
 
-This setup showcases how modifications to the Python environment (like installing packages) are shared across all apps running in the same shared worker.
+This setup showcases how the Python environment (including packages specified in `settings.yaml`) is shared across all apps running in the same shared worker.
 
 ## How to Run
 
@@ -16,4 +16,4 @@ This setup showcases how modifications to the Python environment (like installin
 2.  **Open `index.html`**:
     -   Open the `index.html` file in this directory in a web browser. This file displays both apps side-by-side in iframes.
 
-First, click the "Install `mpmath` package" button in the "Installer App". Once it's installed, click the "Try to use `mpmath`" button in the "User App". You should see a success message and the result of the `mpmath.fadd()` function.
+The 'Installer App' explains the setup. You can go directly to the 'User App' and click the "Use `mpmath` package" button to see that the package is available and works correctly.

--- a/example/Example_7_shared_environment/installer_app/Installer_App.html
+++ b/example/Example_7_shared_environment/installer_app/Installer_App.html
@@ -21,28 +21,29 @@ mount(
   {
     sharedWorker: true,
     streamlitConfig : {},
-    requirements: ['streamlit'],
+    requirements: ['streamlit', 'mpmath'],
     entrypoint: "app.py",
     pyodideUrl: "https://cdn.jsdelivr.net/pyodide/v0.28.2/full/pyodide.js",
     files: {
 "app.py": `
 import streamlit as st
-import micropip
 
 st.title("Installer App")
-st.write("This app installs the \`mpmath\` package.")
 
-async def install_package():
-    st.write("Installing \`mpmath\`...")
-    await micropip.install('mpmath')
-    st.write("\`mpmath\` installed successfully!")
-    st.write("Now you can use it in the User App.")
+st.info(
+    "This app's \`settings.yaml\` file includes the \`mpmath\` package in its requirements."
+)
 
-# Using a button to trigger the installation
-if st.button("Install \`mpmath\` package"):
-    await install_package()
+st.write(
+    "Because this app and the 'User App' are running in a shared worker "
+    "(\`SHARED_WORKER: true\`), the \`mpmath\` package is available in the "
+    "environment for both apps."
+)
 
-st.info("After clicking the install button, go to the User App to see the effect.")
+st.write(
+    "You can now go to the **User App** and use the \`mpmath\` package without "
+    "any installation needed there."
+)
 
 `,
 

--- a/example/Example_7_shared_environment/installer_app/app.py
+++ b/example/Example_7_shared_environment/installer_app/app.py
@@ -1,17 +1,18 @@
 import streamlit as st
-import micropip
 
 st.title("Installer App")
-st.write("This app installs the `mpmath` package.")
 
-async def install_package():
-    st.write("Installing `mpmath`...")
-    await micropip.install('mpmath')
-    st.write("`mpmath` installed successfully!")
-    st.write("Now you can use it in the User App.")
+st.info(
+    "This app's `settings.yaml` file includes the `mpmath` package in its requirements."
+)
 
-# Using a button to trigger the installation
-if st.button("Install `mpmath` package"):
-    await install_package()
+st.write(
+    "Because this app and the 'User App' are running in a shared worker "
+    "(`SHARED_WORKER: true`), the `mpmath` package is available in the "
+    "environment for both apps."
+)
 
-st.info("After clicking the install button, go to the User App to see the effect.")
+st.write(
+    "You can now go to the **User App** and use the `mpmath` package without "
+    "any installation needed there."
+)

--- a/example/Example_7_shared_environment/installer_app/settings.yaml
+++ b/example/Example_7_shared_environment/installer_app/settings.yaml
@@ -3,3 +3,4 @@ APP_ENTRYPOINT: "app.py"
 SHARED_WORKER: true
 APP_REQUIREMENTS:
   - streamlit
+  - mpmath

--- a/example/Example_7_shared_environment/user_app/User_App.html
+++ b/example/Example_7_shared_environment/user_app/User_App.html
@@ -29,18 +29,25 @@ mount(
 import streamlit as st
 
 st.title("User App")
-st.write("This app attempts to use the \`mpmath\` package.")
 
-st.info("First, go to the Installer App and click the install button. Then, come back here and click the button below.")
+st.write(
+    "This app can use the \`mpmath\` package because the 'Installer App' includes it "
+    "in its requirements, and both apps are running in a shared environment."
+)
 
-if st.button("Try to use \`mpmath\`"):
+st.write("Click the button below to test the import and usage.")
+
+if st.button("Use \`mpmath\` package"):
     try:
         import mpmath
         st.success("Successfully imported \`mpmath\`!")
         result = mpmath.fadd(5, 3)
         st.write(f"The result of \`mpmath.fadd(5, 3)\` is: **{result}**")
     except ImportError:
-        st.error("Failed to import \`mpmath\`. Please make sure you have installed it in the Installer App.")
+        st.error(
+            "Failed to import \`mpmath\`. Make sure the 'Installer App' has \`mpmath\` "
+            "in its \`settings.yaml\` requirements."
+        )
     except Exception as e:
         st.error(f"An error occurred: {e}")
 

--- a/example/Example_7_shared_environment/user_app/app.py
+++ b/example/Example_7_shared_environment/user_app/app.py
@@ -1,17 +1,24 @@
 import streamlit as st
 
 st.title("User App")
-st.write("This app attempts to use the `mpmath` package.")
 
-st.info("First, go to the Installer App and click the install button. Then, come back here and click the button below.")
+st.write(
+    "This app can use the `mpmath` package because the 'Installer App' includes it "
+    "in its requirements, and both apps are running in a shared environment."
+)
 
-if st.button("Try to use `mpmath`"):
+st.write("Click the button below to test the import and usage.")
+
+if st.button("Use `mpmath` package"):
     try:
         import mpmath
         st.success("Successfully imported `mpmath`!")
         result = mpmath.fadd(5, 3)
         st.write(f"The result of `mpmath.fadd(5, 3)` is: **{result}**")
     except ImportError:
-        st.error("Failed to import `mpmath`. Please make sure you have installed it in the Installer App.")
+        st.error(
+            "Failed to import `mpmath`. Make sure the 'Installer App' has `mpmath` "
+            "in its `settings.yaml` requirements."
+        )
     except Exception as e:
         st.error(f"An error occurred: {e}")


### PR DESCRIPTION
This commit refactors Example 7 to load the `mpmath` package by adding it to the `APP_REQUIREMENTS` in `settings.yaml`, rather than installing it dynamically with a button click.

This change was made at the user's request to ensure the example works reliably. The previous method of using `micropip.install` was failing in the shared worker environment.

The following files have been updated to reflect this new logic:
- `installer_app/settings.yaml`: Added `mpmath`.
- `installer_app/app.py`: Removed installation logic and updated UI text.
- `user_app/app.py`: Updated UI text.
- `README.md`: Updated to describe the new behavior.
- The HTML files for both apps have been regenerated.