### PR TITLE
fix(example7): Add retry logic to fix race condition

### DIFF
--- a/example/Example_7_shared_environment/user_app/User_App.html
+++ b/example/Example_7_shared_environment/user_app/User_App.html
@@ -27,6 +27,7 @@ mount(
     files: {
 "app.py": `
 import streamlit as st
+import asyncio
 
 st.title("User App")
 
@@ -35,21 +36,42 @@ st.write(
     "in its requirements, and both apps are running in a shared environment."
 )
 
+st.write(
+    "However, due to a potential race condition where this app may start before the "
+    "other app has finished installing the package, a retry mechanism has been added."
+)
+
 st.write("Click the button below to test the import and usage.")
 
 if st.button("Use \`mpmath\` package"):
-    try:
-        import mpmath
-        st.success("Successfully imported \`mpmath\`!")
-        result = mpmath.fadd(5, 3)
-        st.write(f"The result of \`mpmath.fadd(5, 3)\` is: **{result}**")
-    except ImportError:
-        st.error(
-            "Failed to import \`mpmath\`. Make sure the 'Installer App' has \`mpmath\` "
-            "in its \`settings.yaml\` requirements."
-        )
-    except Exception as e:
-        st.error(f"An error occurred: {e}")
+    package_name = "mpmath"
+    max_retries = 5
+    retry_delay = 2  # seconds
+
+    for attempt in range(max_retries):
+        try:
+            # Try to import the package
+            __import__(package_name)
+
+            # If successful, import it properly and use it
+            import mpmath
+            st.success(f"Successfully imported \`{package_name}\` on attempt {attempt + 1}!")
+            result = mpmath.fadd(5, 3)
+            st.write(f"The result of \`mpmath.fadd(5, 3)\` is: **{result}**")
+
+            # Exit the loop on success
+            break
+
+        except ImportError:
+            if attempt < max_retries - 1:
+                st.info(f"Attempt {attempt + 1}: Failed to import \`{package_name}\`. Retrying in {retry_delay} seconds...")
+                await asyncio.sleep(retry_delay)
+            else:
+                st.error(
+                    f"Failed to import \`{package_name}\` after {max_retries} attempts. "
+                    "Please ensure the 'Installer App' is running and has \`mpmath\` "
+                    "in its \`settings.yaml\` requirements."
+                )
 
 `,
 

--- a/example/Example_7_shared_environment/user_app/app.py
+++ b/example/Example_7_shared_environment/user_app/app.py
@@ -1,4 +1,5 @@
 import streamlit as st
+import asyncio
 
 st.title("User App")
 
@@ -7,18 +8,39 @@ st.write(
     "in its requirements, and both apps are running in a shared environment."
 )
 
+st.write(
+    "However, due to a potential race condition where this app may start before the "
+    "other app has finished installing the package, a retry mechanism has been added."
+)
+
 st.write("Click the button below to test the import and usage.")
 
 if st.button("Use `mpmath` package"):
-    try:
-        import mpmath
-        st.success("Successfully imported `mpmath`!")
-        result = mpmath.fadd(5, 3)
-        st.write(f"The result of `mpmath.fadd(5, 3)` is: **{result}**")
-    except ImportError:
-        st.error(
-            "Failed to import `mpmath`. Make sure the 'Installer App' has `mpmath` "
-            "in its `settings.yaml` requirements."
-        )
-    except Exception as e:
-        st.error(f"An error occurred: {e}")
+    package_name = "mpmath"
+    max_retries = 5
+    retry_delay = 2  # seconds
+
+    for attempt in range(max_retries):
+        try:
+            # Try to import the package
+            __import__(package_name)
+
+            # If successful, import it properly and use it
+            import mpmath
+            st.success(f"Successfully imported `{package_name}` on attempt {attempt + 1}!")
+            result = mpmath.fadd(5, 3)
+            st.write(f"The result of `mpmath.fadd(5, 3)` is: **{result}**")
+
+            # Exit the loop on success
+            break
+
+        except ImportError:
+            if attempt < max_retries - 1:
+                st.info(f"Attempt {attempt + 1}: Failed to import `{package_name}`. Retrying in {retry_delay} seconds...")
+                await asyncio.sleep(retry_delay)
+            else:
+                st.error(
+                    f"Failed to import `{package_name}` after {max_retries} attempts. "
+                    "Please ensure the 'Installer App' is running and has `mpmath` "
+                    "in its `settings.yaml` requirements."
+                )


### PR DESCRIPTION
This commit addresses a persistent bug in Example 7 where the User App would fail with an `ImportError`.

The root cause was determined to be a race condition in the `stlite` SharedWorker environment. The User App would attempt to import the shared package before the Installer App had finished downloading and installing it.

This fix implements an asynchronous retry mechanism in `user_app/app.py`. The app now attempts to import the package multiple times with a delay, making the example robust against timing issues and correctly demonstrating the shared environment functionality. The user-facing text has also been updated to explain the new mechanism.