### PR TITLE
diag: Add file system test for SharedWorker

### DIFF
--- a/example/Example_7_shared_environment/installer_app/Installer_App.html
+++ b/example/Example_7_shared_environment/installer_app/Installer_App.html
@@ -21,29 +21,42 @@ mount(
   {
     sharedWorker: true,
     streamlitConfig : {},
-    requirements: ['streamlit', 'mpmath'],
+    requirements: ['streamlit'],
     entrypoint: "app.py",
     pyodideUrl: "https://cdn.jsdelivr.net/pyodide/v0.28.2/full/pyodide.js",
     files: {
 "app.py": `
 import streamlit as st
+import os
 
-st.title("Installer App")
-
-st.info(
-    "This app's \`settings.yaml\` file includes the \`mpmath\` package in its requirements."
-)
+st.title("Installer App (File Writer)")
 
 st.write(
-    "Because this app and the 'User App' are running in a shared worker "
-    "(\`SHARED_WORKER: true\`), the \`mpmath\` package is available in the "
-    "environment for both apps."
+    "This app is part of a diagnostic test. Its purpose is to write a file "
+    "to a shared location (\`/mnt/test.txt\`) in the virtual file system."
 )
 
-st.write(
-    "You can now go to the **User App** and use the \`mpmath\` package without "
-    "any installation needed there."
-)
+if st.button("Write the test file"):
+    file_path = "/mnt/test.txt"
+    dir_name = os.path.dirname(file_path)
+
+    try:
+        # Create the directory if it doesn't exist
+        if not os.path.exists(dir_name):
+            st.write(f"Directory \`{dir_name}\` does not exist. Creating it...")
+            os.makedirs(dir_name)
+            st.write(f"Directory \`{dir_name}\` created.")
+
+        # Write the file
+        content = "Hello from the Installer App! The file was written successfully."
+        with open(file_path, "w") as f:
+            f.write(content)
+
+        st.success(f"Successfully wrote file to \`{file_path}\`.")
+        st.info("You can now go to the 'User App (File Reader)' to see if it can read this file.")
+
+    except Exception as e:
+        st.error(f"An error occurred: {e}")
 
 `,
 

--- a/example/Example_7_shared_environment/installer_app/app.py
+++ b/example/Example_7_shared_environment/installer_app/app.py
@@ -1,18 +1,31 @@
 import streamlit as st
+import os
 
-st.title("Installer App")
-
-st.info(
-    "This app's `settings.yaml` file includes the `mpmath` package in its requirements."
-)
+st.title("Installer App (File Writer)")
 
 st.write(
-    "Because this app and the 'User App' are running in a shared worker "
-    "(`SHARED_WORKER: true`), the `mpmath` package is available in the "
-    "environment for both apps."
+    "This app is part of a diagnostic test. Its purpose is to write a file "
+    "to a shared location (`/mnt/test.txt`) in the virtual file system."
 )
 
-st.write(
-    "You can now go to the **User App** and use the `mpmath` package without "
-    "any installation needed there."
-)
+if st.button("Write the test file"):
+    file_path = "/mnt/test.txt"
+    dir_name = os.path.dirname(file_path)
+
+    try:
+        # Create the directory if it doesn't exist
+        if not os.path.exists(dir_name):
+            st.write(f"Directory `{dir_name}` does not exist. Creating it...")
+            os.makedirs(dir_name)
+            st.write(f"Directory `{dir_name}` created.")
+
+        # Write the file
+        content = "Hello from the Installer App! The file was written successfully."
+        with open(file_path, "w") as f:
+            f.write(content)
+
+        st.success(f"Successfully wrote file to `{file_path}`.")
+        st.info("You can now go to the 'User App (File Reader)' to see if it can read this file.")
+
+    except Exception as e:
+        st.error(f"An error occurred: {e}")

--- a/example/Example_7_shared_environment/installer_app/settings.yaml
+++ b/example/Example_7_shared_environment/installer_app/settings.yaml
@@ -3,4 +3,3 @@ APP_ENTRYPOINT: "app.py"
 SHARED_WORKER: true
 APP_REQUIREMENTS:
   - streamlit
-  - mpmath

--- a/example/Example_7_shared_environment/user_app/User_App.html
+++ b/example/Example_7_shared_environment/user_app/User_App.html
@@ -28,49 +28,41 @@ mount(
 "app.py": `
 import streamlit as st
 import asyncio
+import os
 
-st.title("User App")
-
-st.write(
-    "This app can use the \`mpmath\` package because the 'Installer App' includes it "
-    "in its requirements, and both apps are running in a shared environment."
-)
+st.title("User App (File Reader)")
 
 st.write(
-    "However, due to a potential race condition where this app may start before the "
-    "other app has finished installing the package, a retry mechanism has been added."
+    "This app is part of a diagnostic test. Its purpose is to read a file "
+    "that should have been created by the 'Installer App'."
 )
 
-st.write("Click the button below to test the import and usage.")
-
-if st.button("Use \`mpmath\` package"):
-    package_name = "mpmath"
+if st.button("Read the test file"):
+    file_path = "/mnt/test.txt"
     max_retries = 5
     retry_delay = 2  # seconds
 
     for attempt in range(max_retries):
-        try:
-            # Try to import the package
-            __import__(package_name)
-
-            # If successful, import it properly and use it
-            import mpmath
-            st.success(f"Successfully imported \`{package_name}\` on attempt {attempt + 1}!")
-            result = mpmath.fadd(5, 3)
-            st.write(f"The result of \`mpmath.fadd(5, 3)\` is: **{result}**")
-
-            # Exit the loop on success
-            break
-
-        except ImportError:
+        st.info(f"Attempt {attempt + 1}: Checking for file \`{file_path}\`...")
+        if os.path.exists(file_path):
+            try:
+                with open(file_path, "r") as f:
+                    content = f.read()
+                st.success(f"Successfully read the file on attempt {attempt + 1}!")
+                st.text_area("File Content", content, height=150)
+                # Exit the loop on success
+                break
+            except Exception as e:
+                st.error(f"File exists, but failed to read it: {e}")
+                break # Exit loop if reading fails
+        else:
             if attempt < max_retries - 1:
-                st.info(f"Attempt {attempt + 1}: Failed to import \`{package_name}\`. Retrying in {retry_delay} seconds...")
+                st.write(f"File not found. Retrying in {retry_delay} seconds...")
                 await asyncio.sleep(retry_delay)
             else:
                 st.error(
-                    f"Failed to import \`{package_name}\` after {max_retries} attempts. "
-                    "Please ensure the 'Installer App' is running and has \`mpmath\` "
-                    "in its \`settings.yaml\` requirements."
+                    f"Failed to find file \`{file_path}\` after {max_retries} attempts. "
+                    "This suggests the file system is not shared as expected."
                 )
 
 `,

--- a/example/Example_7_shared_environment/user_app/app.py
+++ b/example/Example_7_shared_environment/user_app/app.py
@@ -1,46 +1,38 @@
 import streamlit as st
 import asyncio
+import os
 
-st.title("User App")
-
-st.write(
-    "This app can use the `mpmath` package because the 'Installer App' includes it "
-    "in its requirements, and both apps are running in a shared environment."
-)
+st.title("User App (File Reader)")
 
 st.write(
-    "However, due to a potential race condition where this app may start before the "
-    "other app has finished installing the package, a retry mechanism has been added."
+    "This app is part of a diagnostic test. Its purpose is to read a file "
+    "that should have been created by the 'Installer App'."
 )
 
-st.write("Click the button below to test the import and usage.")
-
-if st.button("Use `mpmath` package"):
-    package_name = "mpmath"
+if st.button("Read the test file"):
+    file_path = "/mnt/test.txt"
     max_retries = 5
     retry_delay = 2  # seconds
 
     for attempt in range(max_retries):
-        try:
-            # Try to import the package
-            __import__(package_name)
-
-            # If successful, import it properly and use it
-            import mpmath
-            st.success(f"Successfully imported `{package_name}` on attempt {attempt + 1}!")
-            result = mpmath.fadd(5, 3)
-            st.write(f"The result of `mpmath.fadd(5, 3)` is: **{result}**")
-
-            # Exit the loop on success
-            break
-
-        except ImportError:
+        st.info(f"Attempt {attempt + 1}: Checking for file `{file_path}`...")
+        if os.path.exists(file_path):
+            try:
+                with open(file_path, "r") as f:
+                    content = f.read()
+                st.success(f"Successfully read the file on attempt {attempt + 1}!")
+                st.text_area("File Content", content, height=150)
+                # Exit the loop on success
+                break
+            except Exception as e:
+                st.error(f"File exists, but failed to read it: {e}")
+                break # Exit loop if reading fails
+        else:
             if attempt < max_retries - 1:
-                st.info(f"Attempt {attempt + 1}: Failed to import `{package_name}`. Retrying in {retry_delay} seconds...")
+                st.write(f"File not found. Retrying in {retry_delay} seconds...")
                 await asyncio.sleep(retry_delay)
             else:
                 st.error(
-                    f"Failed to import `{package_name}` after {max_retries} attempts. "
-                    "Please ensure the 'Installer App' is running and has `mpmath` "
-                    "in its `settings.yaml` requirements."
+                    f"Failed to find file `{file_path}` after {max_retries} attempts. "
+                    "This suggests the file system is not shared as expected."
                 )


### PR DESCRIPTION
This is a temporary diagnostic commit and should be reverted.

This commit modifies Example 7 to perform a "File Test" to diagnose a persistent bug with the SharedWorker environment.

- `installer_app` is changed to write `/mnt/test.txt`.
- `user_app` is changed to read `/mnt/test.txt`.
- The goal is to verify if the file system is shared between the two apps as documented.