### PR TITLE
feat: Add file deletion to Example 9

### DIFF
--- a/example/Example_9_idbfs_file_browser/README.md
+++ b/example/Example_9_idbfs_file_browser/README.md
@@ -10,7 +10,7 @@ This application will list the contents of the `/mnt` directory, which is config
 
 The IDBFS File Browser application has a simple structure:
 
--   `home.py`: The main Streamlit script that lists the files and directories within the `/mnt` directory.
+-   `home.py`: The main Streamlit script that lists files and directories within the `/mnt` directory and provides an option to delete files.
 -   `settings.yaml`: The configuration file for `script2stlite`, which specifies the same `IDBFS_MOUNTPOINTS` as Example 8.
 
 ## Key Features Demonstrated
@@ -18,6 +18,7 @@ The IDBFS File Browser application has a simple structure:
 1.  **Shared Persistent Storage**: This example confirms that the `IDBFS_MOUNTPOINTS` provides a shared and persistent filesystem. By using the same mount point (`/mnt`) as Example 8, this application can access and display the files created by the other.
 2.  **Inter-App Communication via Filesystem**: This demonstrates a powerful pattern for `stlite` applications: using the persistent filesystem as a way for different apps to share data or state without a server.
 3.  **Reading Directory Contents**: The `home.py` script uses standard Python `os.walk()` to traverse the `/mnt` directory and list its contents, showing how to interact with the persistent filesystem.
+4.  **Deleting Files from Persistent Storage**: The application includes a "Delete" button for each file, demonstrating how to remove files from the `IDBFS` filesystem using `os.remove()`. This completes the showcase of CRUD (Create, Read, Update, Delete) operations on the persistent storage when combined with Example 8.
 
 ## Steps to Convert This Streamlit App
 
@@ -72,7 +73,7 @@ print(f"Conversion complete! Check for '{converter.directory}/IDBFS_File_Browser
 
 ### 5. View Your Application
 
-Open the generated `IDBFS_File_Browser.html` in a web browser. You should see `log.txt` listed as a file in the `/mnt` directory. If you run Example 8 again, another timestamp will be added to the log, but the file listing here will remain the same.
+Open the generated `IDBFS_File_Browser.html` in a web browser. You should see `log.txt` listed as a file in the `/mnt` directory, along with a "Delete" button. You can click this button to remove the file from the persistent storage.
 
 You can view the output of this specific example hosted on GitHub Pages here:
 [https://lukeafullard.github.io/script2stlite/example/Example_9_idbfs_file_browser/IDBFS_File_Browser.html](https://lukeafullard.github.io/script2stlite/example/Example_9_idbfs_file_browser/IDBFS_File_Browser.html)

--- a/example/Example_9_idbfs_file_browser/home.py
+++ b/example/Example_9_idbfs_file_browser/home.py
@@ -30,7 +30,26 @@ else:
 
 st.subheader(f"Contents of `{mount_point}`:")
 
-if file_list:
-    st.code("\n".join(sorted(file_list)), language="text")
-else:
+if not file_list:
     st.code(f"The `{mount_point}` directory is empty.", language="text")
+else:
+    st.write("Files in the persistent directory are listed below. You can delete files, but not directories with this tool.")
+    for file_path in sorted(file_list):
+        # We can only delete files, not directories, with this simple implementation.
+        is_file = not file_path.endswith('/')
+
+        col1, col2 = st.columns([0.8, 0.2])
+
+        with col1:
+            st.code(file_path, language="text")
+
+        if is_file:
+            with col2:
+                if st.button("Delete", key=f"delete_{file_path}", use_container_width=True):
+                    try:
+                        full_path = os.path.join(mount_point, file_path)
+                        os.remove(full_path)
+                        st.success(f"Deleted `{file_path}`")
+                        st.rerun()
+                    except Exception as e:
+                        st.error(f"Error deleting `{file_path}`: {e}")


### PR DESCRIPTION
This commit adds a file deletion feature to the IDBFS File Browser example.

The `home.py` script is modified to display a "Delete" button next to each file listed from the persistent `/mnt` directory. When clicked, the corresponding file is removed using `os.remove()` and the app is re-run to display the updated file list.

The `README.md` for Example 9 is also updated to document this new capability, explaining how it demonstrates file removal from the persistent storage.