### PR TITLE
docs: Correct CONFIG value in README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ APP_REQUIREMENTS: #app requirements separated by a '-' on each new line. Require
   - pandas
   - numpy
 APP_ENTRYPOINT: home.py #entrypoint to app - main python file
-CONFIG: false
+CONFIG: "none"
 APP_FILES:  #each file separated by a '-'. Can be .py files or other filetypes that will be converted to binary and embeded in the html.
   - functions.py #additional files for the conversion to find and include.
   - assets/image.jpg


### PR DESCRIPTION
The `settings.yaml` code snippet in the "Quick Start" section of the `README.md` had `CONFIG: false`, while the actual example file uses `CONFIG: "none"`.

This commit updates the `README.md` to match the example file.