### PR TITLE
Fix: Encoding issue on Windows (CP932) by explicitly specifying UTF-8 in write_text_file

### DIFF
--- a/script2stlite/functions.py
+++ b/script2stlite/functions.py
@@ -515,7 +515,11 @@ def file_to_ou_base64_string(file_path: str) -> str:
         encoded: bytes = base64.b64encode(f.read())
         return encoded.decode("utf-8")
 ############################################################################### 
-def write_text_file(filename: str, content: str) -> None:
+def write_text_file(
+    filename: str,
+    content: str,
+    encoding: str = "utf-8"
+) -> None:
     """
     Write text content to a file.
 
@@ -531,7 +535,7 @@ def write_text_file(filename: str, content: str) -> None:
     None
     """
     try:
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding=encoding) as f:
             f.write(content)
         print(f"Content successfully written to {filename}")
     except IOError:


### PR DESCRIPTION
## Overview
Added an `encoding` parameter to the `write_text_file` function to support flexible file writing with different character encodings. 

Closes #74

## Changes
- Updated the `write_text_file` function signature
  - New parameter:  `encoding: str = "utf-8"` (defaults to utf-8)

- Added encoding support to file writing operation
  - Added `encoding` parameter to the `open()` function call
