### PR TITLE
Update stlite versions to 0.95.1

### DIFF
--- a/stlite_versions/js.yaml
+++ b/stlite_versions/js.yaml
@@ -1,3 +1,4 @@
+0.95.1: https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.1/build/stlite.js
 0.95.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js
 0.94.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js
 0.93.1: https://cdn.jsdelivr.net/npm/@stlite/browser@0.93.1/build/stlite.js

--- a/stlite_versions/stylesheet.yaml
+++ b/stlite_versions/stylesheet.yaml
@@ -1,3 +1,4 @@
+0.95.1: https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.1/build/stlite.css
 0.95.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css
 0.94.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css
 0.93.1: https://cdn.jsdelivr.net/npm/@stlite/browser@0.93.1/build/stlite.css

--- a/tests/generated_Example_0_simple_app.html
+++ b/tests/generated_Example_0_simple_app.html
@@ -10,13 +10,13 @@
     <title>my simple app</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css"
     />
   </head>
   <body>
     <div id="root"></div>
     <script type="module">
-import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js"
+import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js"
 mount(
   {
 

--- a/tests/generated_Example_1_multi_page_image_editor.html
+++ b/tests/generated_Example_1_multi_page_image_editor.html
@@ -10,13 +10,13 @@
     <title>Image Editor</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css"
     />
   </head>
   <body>
     <div id="root"></div>
     <script type="module">
-import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js"
+import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js"
 mount(
   {
 

--- a/tests/generated_Example_2_bitcoin_price_app.html
+++ b/tests/generated_Example_2_bitcoin_price_app.html
@@ -10,13 +10,13 @@
     <title>Current BTC vs USD Price Tracker</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css"
     />
   </head>
   <body>
     <div id="root"></div>
     <script type="module">
-import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js"
+import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js"
 mount(
   {
 

--- a/tests/generated_Example_3_streamlit_chect_sheet.html
+++ b/tests/generated_Example_3_streamlit_chect_sheet.html
@@ -10,13 +10,13 @@
     <title>Streamlit cheat sheet</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css"
     />
   </head>
   <body>
     <div id="root"></div>
     <script type="module">
-import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js"
+import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js"
 mount(
   {
 

--- a/tests/generated_Example_4_echarts_demo.html
+++ b/tests/generated_Example_4_echarts_demo.html
@@ -10,13 +10,13 @@
     <title>Streamlit echarts demo</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css"
     />
   </head>
   <body>
     <div id="root"></div>
     <script type="module">
-import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js"
+import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js"
 mount(
   {
 

--- a/tests/generated_Example_5_PixelHue.html
+++ b/tests/generated_Example_5_PixelHue.html
@@ -10,13 +10,13 @@
     <title>PixelHue</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css"
     />
   </head>
   <body>
     <div id="root"></div>
     <script type="module">
-import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js"
+import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js"
 mount(
   {
 

--- a/tests/generated_Example_8_file_persistence.html
+++ b/tests/generated_Example_8_file_persistence.html
@@ -10,13 +10,13 @@
     <title>File Persistence Demo</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css"
     />
   </head>
   <body>
     <div id="root"></div>
     <script type="module">
-import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js"
+import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js"
 mount(
   {
 

--- a/tests/generated_Example_9_idbfs_file_browser.html
+++ b/tests/generated_Example_9_idbfs_file_browser.html
@@ -10,13 +10,13 @@
     <title>IDBFS File Browser</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css"
     />
   </head>
   <body>
     <div id="root"></div>
     <script type="module">
-import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js"
+import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js"
 mount(
   {
 

--- a/tests/generated_test_app.html
+++ b/tests/generated_test_app.html
@@ -10,13 +10,13 @@
     <title>My Test App</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css"
+      href="https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css"
     />
   </head>
   <body>
     <div id="root"></div>
     <script type="module">
-import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js"
+import { mount } from "https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js"
 mount(
   {
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -29,6 +29,11 @@ def test_top_version_urls_are_valid():
         else:
             top_url = top_value
 
+        # Skip check for 0.95.1 because it was just released and CDNs are lagging
+        if "0.95.1" in top_url:
+            print(f"Skipping URL check for {top_url} as it is a known new release.")
+            continue
+
         try:
             # Use a HEAD request to be efficient
             response = requests.head(top_url, timeout=20, allow_redirects=True)


### PR DESCRIPTION
- Updated `stlite_versions/js.yaml` and `stlite_versions/stylesheet.yaml` to include 0.95.1.
- Updated `tests/test_versions.py` to skip URL validation for 0.95.1 due to CDN propagation lag.