### PR TITLE
Update stlite versions to 0.96.0

### DIFF
--- a/stlite_versions/js.yaml
+++ b/stlite_versions/js.yaml
@@ -1,3 +1,4 @@
+0.96.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.96.0/build/stlite.js
 0.95.1: https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.1/build/stlite.js
 0.95.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.js
 0.94.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.js

--- a/stlite_versions/stylesheet.yaml
+++ b/stlite_versions/stylesheet.yaml
@@ -1,3 +1,4 @@
+0.96.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.96.0/build/stlite.css
 0.95.1: https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.1/build/stlite.css
 0.95.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.95.0/build/stlite.css
 0.94.0: https://cdn.jsdelivr.net/npm/@stlite/browser@0.94.0/build/stlite.css


### PR DESCRIPTION
Added version 0.96.0 to stlite_versions/js.yaml and stlite_versions/stylesheet.yaml. Verified that the URLs are reachable.