### PR TITLE
Update pyodide version to 0.29.1 in stlite_versions/pyodide.yaml

### DIFF
--- a/stlite_versions/pyodide.yaml
+++ b/stlite_versions/pyodide.yaml
@@ -1,3 +1,4 @@
+0.29.1: 'pyodideUrl: "https://cdn.jsdelivr.net/pyodide/v0.29.1/full/pyodide.js",'
 0.29.0: 'pyodideUrl: "https://cdn.jsdelivr.net/pyodide/v0.29.0/full/pyodide.js",'
 0.28.3: 'pyodideUrl: "https://cdn.jsdelivr.net/pyodide/v0.28.3/full/pyodide.js",'
 0.28.2: 'pyodideUrl: "https://cdn.jsdelivr.net/pyodide/v0.28.2/full/pyodide.js",'


### PR DESCRIPTION
- Added version 0.29.1 to the top of `stlite_versions/pyodide.yaml`.
- Verified the URL is reachable using `tests/test_versions.py`.